### PR TITLE
Scale creature models to quarter size

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -2,7 +2,7 @@
 (function(global){
   const THREE=global.THREE;
   function Controls(cam,dom){this.object=cam;this.domElement=dom;this.target=new THREE.Vector3(0,0,0);
-    this.maxPolarAngle=Math.PI*0.49;this.minDistance=8;this.maxDistance=150;
+    this.maxPolarAngle=Math.PI*0.49;this.minDistance=2;this.maxDistance=150;
     let st=null,sx=0,sy=0,phi=0.9,theta=0.8,rad=45;
     const upd=()=>{const sp=Math.max(0.05,Math.min(this.maxPolarAngle,phi));rad=Math.max(this.minDistance,Math.min(this.maxDistance,rad));
       const x=this.target.x+rad*Math.sin(sp)*Math.sin(theta),y=this.target.y+rad*Math.cos(sp),z=this.target.z+rad*Math.sin(sp)*Math.cos(theta);
@@ -67,7 +67,7 @@
     return new this._THREE.Color().setHSL(hue,0.85,(e.mode==='swim'?0.65:0.55));
   };
   CMesh.prototype.update=function(list){
-    const CREATURE_SCALE = 0.1;
+    const CREATURE_SCALE = 0.25;
     const seen=new Set();
     const n=Math.min(list.length,this.cap);
     this._time=(this._time||0)+0.1;const t=this._time;

--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -2,7 +2,7 @@
 // Worker v9 (terrain-following + natural selection + speciation)
 let entities=[],plants=[],devices=[];
 let world={t:0,bounds:28,season:0,seasonSpeed:1,simCap:4000};
-const CREATURE_SCALE = 0.1;
+const CREATURE_SCALE = 0.25;
 let randState=123456789; function rand(){randState^=randState<<13;randState^=randState>>>17;randState^=randState<<5;return (randState>>>0)/4294967296;}
 function clamp01(v){return Math.max(0,Math.min(1,v));} function lerp(a,b,t){return a+(b-a)*t;}
 // Map


### PR DESCRIPTION
## Summary
- Size creatures using shared `CREATURE_SCALE` constant set to `0.25`
- Adjust camera controls to allow closer zooming for smaller models

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a03839de848333b90337da602765cb