### PR TITLE
feat: add biome resources

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -6,16 +6,24 @@ const CREATURE_SCALE = 0.25;
 let randState=123456789; function rand(){randState^=randState<<13;randState^=randState>>>17;randState^=randState<<5;return (randState>>>0)/4294967296;}
 function clamp01(v){return Math.max(0,Math.min(1,v));} function lerp(a,b,t){return a+(b-a)*t;}
 // Map
-const VERT=8.0; let map={size:96,heights:new Float32Array(96*96),biomes:new Uint8Array(96*96),step:0.3,waterLevel:-0.18};
+const VERT=8.0; let map={size:96,heights:new Float32Array(96*96),biomes:new Uint8Array(96*96),resources:new Float32Array(96*96),resMax:new Float32Array(96*96),resRegen:new Float32Array(96*96),step:0.3,waterLevel:-0.18};
 function noise2d(x,y,seed){function h(n){const s=Math.sin(n*0.0007+seed*1e-6)*43758.5453;return s-Math.floor(s);}const xi=Math.floor(x),yi=Math.floor(y),xf=x-xi,yf=y-yi;function f(t){return t*t*(3-2*t);}const tl=h(xi*157+yi*311),tr=h((xi+1)*157+yi*311),bl=h(xi*157+(yi+1)*311),br=h((xi+1)*157+(yi+1)*311);const u=f(xf),v=f(yf);return lerp(lerp(tl,tr,u),lerp(bl,br,u),v);} function ridged(x,y,seed){const n=noise2d(x,y,seed);return 1-Math.abs(n*2-1);}
-function generateMap(p){const N=p.size||96;map.size=N;map.heights=new Float32Array(N*N);map.biomes=new Uint8Array(N*N);map.step=p.step||0.3;
+function generateMap(p){const N=p.size||96;map.size=N;map.heights=new Float32Array(N*N);map.biomes=new Uint8Array(N*N);map.resources=new Float32Array(N*N);map.resMax=new Float32Array(N*N);map.resRegen=new Float32Array(N*N);map.step=p.step||0.3;
   const seed=(p.seed||12345)>>>0,slope=p.slope||1.1,mount=p.mount||1.0, rivers=!!p.rivers, set=p.biomes||['plains','forest','desert','wetland','tundra'];
   for(let z=0;z<N;z++){for(let x=0;x<N;x++){let h=(noise2d(x*0.05,z*0.05,seed)-0.5)*2.0;h+=(noise2d(x*0.015,z*0.015,seed+1337)-0.5)*1.2;h+=(ridged(x*0.12,z*0.12,seed+5555)-0.5)*2.0*mount;h*=slope;const q=Math.round(h/map.step)*map.step;h=0.7*q+0.3*h;map.heights[z*N+x]=h;}}let mn=1e9,mx=-1e9;for(let i=0;i<N*N;i++){const v=map.heights[i];if(v<mn)mn=v;if(v>mx)mx=v;}const rg=mx-mn||1;for(let i=0;i<N*N;i++){map.heights[i]=((map.heights[i]-mn)/rg)*1.2-0.6;}
   if(rivers){for(let z=0;z<N;z++){for(let x=0;x<N;x++){const r=ridged(x*0.05,z*0.05,seed+9909);const d=(1-r);const dig=Math.max(0,d-0.6)*0.55;const i=z*N+x;map.heights[i]-=dig;}}}
   function ok(n){return set.indexOf(n)>=0;}
-  for(let z=0;z<N;z++){for(let x=0;x<N;x++){const i=z*N+x,e=map.heights[i], temp=1-Math.abs((z/N)*2-1), moist=noise2d(x*0.05,z*0.05,seed+4242);let b=0;if(e<map.waterLevel&&ok('wetland'))b=3;else if(temp<0.25&&ok('tundra'))b=4;else if(moist<0.28&&ok('desert'))b=2;else if(moist>0.65&&ok('forest'))b=1;else b=0;map.biomes[i]=b;}}
+  for(let z=0;z<N;z++){
+    for(let x=0;x<N;x++){
+      const i=z*N+x,e=map.heights[i], temp=1-Math.abs((z/N)*2-1), moist=noise2d(x*0.05,z*0.05,seed+4242);
+      let b=0;if(e<map.waterLevel&&ok('wetland'))b=3;else if(temp<0.25&&ok('tundra'))b=4;else if(moist<0.28&&ok('desert'))b=2;else if(moist>0.65&&ok('forest'))b=1;else b=0;map.biomes[i]=b;
+      let max=0.6,regen=0.02;
+      if(b===1){max=1.0;regen=0.04;} else if(b===2){max=0.3;regen=0.005;} else if(b===3){max=0.8;regen=0.03;} else if(b===4){max=0.5;regen=0.015;}
+      map.resMax[i]=max;map.resources[i]=max;map.resRegen[i]=regen;
+    }
+  }
   const props=[];for(let z=0;z<N;z++){for(let x=0;x<N;x++){const i=z*N+x,e=map.heights[i],bx=(x/(N-1)-0.5)*(world.bounds*2),bz=(z/(N-1)-0.5)*(world.bounds*2),b=map.biomes[i],r=noise2d(x*0.3,z*0.3,seed+4444);if(b===1&&r>0.75&&e>map.waterLevel+0.02)props.push({type:'tree',x:bx,z:bz,y:e,s:0.8+noise2d(x*0.2,z*0.2,seed+1)});if(b===2&&r>0.82&&e>map.waterLevel+0.02)props.push({type:'cactus',x:bx,z:bz,y:e,s:0.8+noise2d(x*0.3,z*0.3,seed+2)});if(b===0&&r>0.85)props.push({type:'rock',x:bx,z:bz,y:e,s:0.6+noise2d(x*0.2,z*0.2,seed+3)});if(b===3&&r>0.78)props.push({type:'reed',x:bx,z:bz,y:e,s:0.7+noise2d(x*0.3,z*0.3,seed+4)});}} 
-  postMessage({type:'map',payload:{size:N,heights:map.heights,biomes:map.biomes,step:map.step,vs:VERT,waterLevel:map.waterLevel,props}});}
+  postMessage({type:'map',payload:{size:N,heights:map.heights,biomes:map.biomes,resources:map.resources,resMax:map.resMax,resRegen:map.resRegen,step:map.step,vs:VERT,waterLevel:map.waterLevel,props}});}
 function mapCoord(x,z){const N=map.size;const fx=((x/(world.bounds*2))+0.5)*(N-1),fz=((z/(world.bounds*2))+0.5)*(N-1);const xi=Math.max(0,Math.min(N-2,Math.floor(fx))),zi=Math.max(0,Math.min(N-2,Math.floor(fz)));return {N,xi,zi,i:zi*N+xi};}
 function heightRawAt(x,z){const c=mapCoord(x,z);return map.heights[c.i];} function heightAtWorld(x,z){return heightRawAt(x,z)*VERT;}
 function slopeAt(x,z){const c=mapCoord(x,z);const h=map.heights[c.i],hx=map.heights[c.i+1],hz=map.heights[c.i+c.N];return Math.sqrt((hx-h)*(hx-h)+(hz-h)*(hz-h));}


### PR DESCRIPTION
## Summary
- track resources per tile in map object with resource, max, and regen arrays
- initialize tile resources based on biome in `generateMap`

## Testing
- `node --check src/sim/worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68a04bca3e3c833380fbec9aa7248d97