### PR TITLE
Expose resource arrays in snapshot

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -138,6 +138,8 @@ function tick(dt){
   }
 }
 function snapshot(){
+  world.resources = map.resources;
+  world.resMax = map.resMax;
   const list=new Array(entities.length);
   for(let i=0;i<entities.length;i++){
     const e=entities[i];


### PR DESCRIPTION
## Summary
- include map resource arrays in world snapshot

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/EvoTerrarium/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a068bc0c00833384e7ffaba7e9f59e