### PR TITLE
Balance herbivore energy intake and costs

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -11,6 +11,8 @@ const RES_GRAD_BASE = 0.9;              // base acceleration from resource gradi
 const RES_GRAD_LOW_RES_BOOST = 1.5;     // extra boost when resources are scarce
 const RES_LOW_THRESHOLD = 0.3;          // threshold for low resource level
 const BASAL_COMFORT_FACTOR = 0.5;
+const HERBIVORE_INTAKE_COEF = 0.35;     // plant energy intake multiplier for herbivores
+const HERBIVORE_COST_MULT = 0.5;        // scales movement and basal costs for herbivores
 let randState=123456789; function rand(){randState^=randState<<13;randState^=randState>>>17;randState^=randState<<5;return (randState>>>0)/4294967296;}
 function clamp01(v){return Math.max(0,Math.min(1,v));} function lerp(a,b,t){return a+(b-a)*t;}
 function maxEnergy(size){ return 1.0 + size * 2.0; }
@@ -168,9 +170,10 @@ function tick(dt){
     e.x+=e.vx*dt; e.z+=e.vz*dt; const B=world.bounds-1.0; if(e.x<-B){e.x=-B;e.vx*=-0.8;} if(e.x>B){e.x=B;e.vx*=-0.8;} if(e.z<-B){e.z=-B;e.vz*=-0.8;} if(e.z>B){e.z=B;e.vz*=-0.8;}
     const gY=heightAtWorld(e.x,e.z); e.y=gY+(inWater?(map.waterLevel*VERT-gY):0)+(inWater?0.15:0.35)*CREATURE_SCALE; if(avoidSlope>0.6){e.vx-=Math.sign(e.vx)*0.02; e.vz-=Math.sign(e.vz)*0.02;}
     const biome=b; const biomeMul=(biome===2?0.6:(biome===3?1.3:(biome===4?0.7:1.0)));
-    let intake=(e.genes.diet===0)?(0.7*plantRichnessAt(e.x,e.z)*biomeMul):0;
-    const moveCost=(0.002+0.0006*sp2)*(0.8+e.genes.size*0.6)*(1+avoidSlope*0.8+(inWater?(1-e.genes.swim)*0.9:0));
-    const basal=(0.0008+0.0006*e.genes.size+(e.genes.diet===1?0.0006:0))*comfortCoef;
+    const dietCostMult=(e.genes.diet===0)?HERBIVORE_COST_MULT:1.0;
+    let intake=(e.genes.diet===0)?(HERBIVORE_INTAKE_COEF*plantRichnessAt(e.x,e.z)*biomeMul):0;
+    const moveCost=(0.002+0.0006*sp2)*(0.8+e.genes.size*0.6)*(1+avoidSlope*0.8+(inWater?(1-e.genes.swim)*0.9:0))*dietCostMult;
+    const basal=(0.0008+0.0006*e.genes.size+(e.genes.diet===1?0.0006:0))*comfortCoef*dietCostMult;
     if(e.genes.diet===0){
       const {i}=mapCoord(e.x,e.z);
       const available=map.resources[i];


### PR DESCRIPTION
## Summary
- Reduce herbivore plant intake coefficient and expose as `HERBIVORE_INTAKE_COEF`
- Scale herbivore movement and basal costs with `HERBIVORE_COST_MULT` to rebalance energy use

## Testing
- `node --check src/sim/worker.js`
- `node <<'NODE'
const HERBIVORE_INTAKE_COEF = 0.35;
const HERBIVORE_COST_MULT = 0.5;
const plant = 0.5; // sample plant richness
const biomeMul = 1.0;
const sp2 = 0.1; const size = 0.5; const avoidSlope = 0; const inWater=false; const comfortCoef=1;
let intake=HERBIVORE_INTAKE_COEF*plant*biomeMul;
const moveCost=(0.002+0.0006*sp2)*(0.8+size*0.6)*(1+avoidSlope*0.8+(inWater?(1-0)*0.9:0))*HERBIVORE_COST_MULT;
const basal=(0.0008+0.0006*size)*comfortCoef*HERBIVORE_COST_MULT;
console.log({intake, moveCost, basal, net:intake - (moveCost+basal)});
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a183e537bc8333ba3a0b74679144f1