### PR TITLE
Add creature selection info panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
 
   <canvas id="tree" style="position:fixed;top:0;left:0;width:100vw;height:100vh;display:none;pointer-events:auto;"></canvas>
 
+  <div id="creatureInfo"></div>
+
   <div id="hud">
     <div class="pill" id="stats">booting…</div>
     <div class="pill" id="diag">diag: html</div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -10,3 +10,6 @@ html,body{margin:0;padding:0;height:100%;width:100%;background:#0f151d;color:#e6
 #panel #modes button{background:rgba(0,0,0,.35)}
 #panel #modes button.on{background:rgba(120,180,255,.25)}
 #diag{max-width:40vw;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+
+#creatureInfo{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:rgba(0,0,0,.8);border:1px solid rgba(255,255,255,.2);border-radius:8px;padding:10px 14px;display:none;z-index:5;color:#e6eef5;pointer-events:auto}
+#creatureInfo div{margin-bottom:4px}

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -149,11 +149,39 @@
   const statsEl=document.getElementById('stats');const seasonSpeed=document.getElementById('seasonSpeed');
   const resScale=document.getElementById('resScale');const resScaleReset=document.getElementById('resScaleReset');
   const treeCanvas=document.getElementById('tree');const tctx=treeCanvas.getContext('2d');let treeData={nodes:[]};
+  const infoEl=document.getElementById('creatureInfo');
+  let infoCloser=null;
+  function hideInfo(){
+    if(!infoEl)return;
+    infoEl.style.display='none';
+    if(infoCloser){
+      document.removeEventListener('click',infoCloser);
+      document.removeEventListener('touchstart',infoCloser);
+      infoCloser=null;
+    }
+  }
+  function showInfo(ent){
+    if(!infoEl)return;
+    hideInfo();
+    const g=ent.genes||{};
+    infoEl.innerHTML=`<div><strong>ID:</strong> ${ent.id}</div>
+<div><strong>Energy:</strong> ${ent.energy.toFixed(2)}</div>
+<div><strong>Hydration:</strong> ${ent.hydration.toFixed(2)}</div>
+<div><strong>Age:</strong> ${ent.age.toFixed(2)}</div>
+<div><strong>Species:</strong> ${ent.species}</div>
+<div><strong>Genes:</strong> size ${ (g.size??0).toFixed(2) }, speed ${ (g.speed??0).toFixed(2) }, thermo ${ (g.thermo??0).toFixed(2) }, climb ${ (g.climb??0).toFixed(2) }, swim ${ (g.swim??0).toFixed(2) }, social ${ (g.social??0).toFixed(2) }, diet ${ g.diet }</div>`;
+    infoEl.style.display='block';
+    infoCloser=(ev)=>{if(!infoEl.contains(ev.target))hideInfo();};
+    document.addEventListener('click',infoCloser);
+    document.addEventListener('touchstart',infoCloser);
+  }
+  infoEl&&infoEl.addEventListener('click',e=>e.stopPropagation());
+  infoEl&&infoEl.addEventListener('touchstart',e=>e.stopPropagation());
   function drawTree(){const s=(window.devicePixelRatio||1);treeCanvas.width=window.innerWidth*s;treeCanvas.height=window.innerHeight*s;tctx.setTransform(1,0,0,1,0,0);tctx.clearRect(0,0,treeCanvas.width,treeCanvas.height);tctx.lineWidth=2*s;if(!treeData.nodes.length)return;const maxT=Math.max(...treeData.nodes.map(n=>n.birth));const minT=Math.min(...treeData.nodes.map(n=>n.birth));const G={};treeData.nodes.forEach(n=>{(G[n.parent]||(G[n.parent]=[])).push(n);});function layout(pid,depth,y0){const arr=G[pid]||[];const gap=60*s;let y=y0;for(const n of arr){n._x=(depth+1)*120*s;n._y=y;layout(n.id,depth+1,y);y+=gap;}if(arr.length===0)y=y0+gap;return y;}const root={id:0};root._x=40*s;root._y=40*s;layout(0,0,80*s);tctx.font=`${12*s}px sans-serif`;for(const n of treeData.nodes){const hue=(n.hue||0.35);tctx.fillStyle=`hsl(${Math.floor((hue*360)%360)},70%,60%)`;tctx.beginPath();tctx.arc(n._x,n._y,8*s,0,Math.PI*2);tctx.fill();tctx.fillText(String(n.id),n._x+10*s,n._y-8*s);}for(const n of treeData.nodes){const arr=G[n.parent]||[];for(const ch of arr){tctx.strokeStyle='rgba(255,255,255,0.35)';tctx.beginPath();tctx.moveTo(n._x,n._y);tctx.lineTo(ch._x,ch._y);tctx.stroke();}}}
   function showTree(v){treeCanvas.style.display=v?'block':'none';if(v)drawTree();}
   treeCanvas.addEventListener('click',e=>{const s=(window.devicePixelRatio||1),r=treeCanvas.getBoundingClientRect();const x=(e.clientX-r.left)*s,y=(e.clientY-r.top)*s;for(const n of treeData.nodes){const dx=x-n._x,dy=y-n._y;if(dx*dx+dy*dy<14*14*s){sim&&sim.postMessage({type:'selectSpecies',payload:{species:n.id}});showTree(false);break;}}});
   function applyMap(data){engine.rebuildTerrain(data);}
-  if(sim){sim.onmessage=(e)=>{const t=e.data.type,p=e.data.payload;if(t==='state'){creatures.update(p.entities);engine.updateTerrain(p.world);engine.updateDevices(p.devices||[]);const maxE=p.entities.reduce((m,e)=>Math.max(m,e.maxEnergy||0),0);statsEl.textContent=`entities: ${p.entities.length} • time: ${p.world.t.toFixed(1)}s • season:${p.world.season.toFixed(2)} • maxE:${maxE.toFixed(2)}`;d('state ok');}else if(t==='map'){applyMap(p);}else if(t==='tree'){treeData=p;showTree(true);}else if(t==='selected'){engine.highlightAt(p);}else if(t==='rpgReady'){d('RPG species selected: '+p.species);}else if(t==='error'){statsEl.textContent='worker error: '+p;d('worker error: '+p);}};sim.postMessage({type:'init',payload:{seed:Date.now(),entityCount:200,simCap:parseInt(document.getElementById('simCap').value,10)}});}
+  if(sim){sim.onmessage=(e)=>{const t=e.data.type,p=e.data.payload;if(t==='state'){creatures.update(p.entities);engine.updateTerrain(p.world);engine.updateDevices(p.devices||[]);const maxE=p.entities.reduce((m,e)=>Math.max(m,e.maxEnergy||0),0);statsEl.textContent=`entities: ${p.entities.length} • time: ${p.world.t.toFixed(1)}s • season:${p.world.season.toFixed(2)} • maxE:${maxE.toFixed(2)}`;d('state ok');}else if(t==='map'){applyMap(p);}else if(t==='tree'){treeData=p;showTree(true);}else if(t==='selected'){engine.highlightAt(p);showInfo(p);}else if(t==='rpgReady'){d('RPG species selected: '+p.species);}else if(t==='error'){statsEl.textContent='worker error: '+p;d('worker error: '+p);}};sim.postMessage({type:'init',payload:{seed:Date.now(),entityCount:200,simCap:parseInt(document.getElementById('simCap').value,10)}});}
   engine.start();
   seasonSpeed.addEventListener('input',function(){sim&&sim.postMessage({type:'seasonSpeed',payload:parseFloat(this.value)})});
   resScale&&resScale.addEventListener('input',function(){const newScale=parseFloat(this.value);sim&&sim.postMessage({type:'resourceScale', payload:newScale});});

--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -313,7 +313,14 @@ let timer=null; onmessage=(e)=>{try{const t=e.data.type,p=e.data.payload;
   if(t==='init'){init((p&&p.seed)||1,(p&&p.entityCount)||200,p&&p.simCap||4000); if(timer)clearInterval(timer); const dt=0.1; timer=setInterval(()=>{tick(dt);snapshot();},100);}
   else if(t==='seasonSpeed'){world.seasonSpeed=p||1.0;}
   else if(t==='placeDevice'){devices.push({type:p.type,x:p.x,z:p.z,power:1.0,radius:5.0});}
-  else if(t==='pickSelect'){let best=null,bd2=1e9;for(const ent of entities){const dx=ent.x-p.x,dz=ent.z-p.z,d2=dx*dx+dz*dz;if(d2<bd2){bd2=d2;best=ent;}} if(best)postMessage({type:'selected',payload:{x:best.x,z:best.z}});}
+  else if(t==='pickSelect'){
+    let best=null,bd2=1e9;
+    for(const ent of entities){
+      const dx=ent.x-p.x,dz=ent.z-p.z,d2=dx*dx+dz*dz;
+      if(d2<bd2){bd2=d2;best=ent;}
+    }
+    if(best)postMessage({type:'selected',payload:best});
+  }
   else if(t==='regenMap'){generateMap(p||{seed:Date.now(),size:96,smooth:0.3,slope:1.1,mount:1.0,rivers:true});}
   else if(t==='getTree'){postMessage({type:'tree',payload:{nodes:treeNodes}});}
   else if(t==='selectSpecies'){postMessage({type:'rpgReady',payload:{species:p.species}});}


### PR DESCRIPTION
## Summary
- return full entity data on selection from simulation worker
- add creature info popup with styles
- show creature attributes in popup and hide on outside click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a28e9831988333bde7fcf38900fead