### PR TITLE
Adjust entity reproduction cooldown

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -123,7 +123,7 @@ function spawnEntity(id){
   speciesHues[sp]=rand();
   regSpecies(sp,0);
   const energy=maxEnergy(g.size)*0.6;
-  return {id,x,z,y:heightAtWorld(x,z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,age:0.0,hydration:1.0,cooldown:rand()*6,genes:g,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5)};
+  return {id,x,z,y:heightAtWorld(x,z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,age:0.0,hydration:1.0,cooldown:30+rand()*30,genes:g,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5)};
 }
 function reproduce(p){
   const cg=newGenes(p.genes);
@@ -136,7 +136,7 @@ function reproduce(p){
     regSpecies(sp,p.species);
   }
   const energy=maxEnergy(cg.size)*0.6;
-    entities.push({id:nextId++,x:p.x+(rand()*2-1)*0.5,z:p.z+(rand()*2-1)*0.5,y:heightAtWorld(p.x,p.z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,hydration:0.8,age:0.0,cooldown:4+rand()*4,genes:cg,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5)});
+    entities.push({id:nextId++,x:p.x+(rand()*2-1)*0.5,z:p.z+(rand()*2-1)*0.5,y:heightAtWorld(p.x,p.z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,hydration:0.8,age:0.0,cooldown:30+rand()*30,genes:cg,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5)});
 }
 // env
 function comfortTempBase(z){return (Math.sin(z*0.07)*0.5+0.5);} function comfortTempWithDevices(x,z){let t=comfortTempBase(z);for(const d of devices){if(d.type!=='heater')continue;const dx=d.x-x,dz=d.z-z;const r2=dx*dx+dz*dz;const fall=Math.exp(-r2/(d.radius*d.radius));t=clamp01(t+d.power*0.25*fall);}return t;}
@@ -285,7 +285,7 @@ function tick(dt){
       e.hydration=clamp01(e.hydration);
       if (e.hydration <= 0) e.energy -= DEHYDRATION_PENALTY * dt;
       e.energy=maxE*norm(e.energy,maxE);
-      if(entities.length<world.simCap&&e.cooldown<=0&&e.energy>maxE*0.75&&e.hydration>0.3&&e.age>=60){e.cooldown=6+rand()*6;e.energy-=0.6;reproduce(e);} if(e.energy<=0||e.age>300){entities.splice(i,1);continue;}
+      if(entities.length<world.simCap&&e.cooldown<=0&&e.energy>maxE*0.75&&e.hydration>0.3&&e.age>=60){e.cooldown=30+rand()*30;e.energy-=0.6;reproduce(e);} if(e.energy<=0||e.age>300){entities.splice(i,1);continue;}
     e.yaw=Math.atan2(e.vx,e.vz);
   }
 }


### PR DESCRIPTION
## Summary
- extend parent cooldown after reproduction from up to 12 ticks to up to 60
- initialize new offspring and natural spawns with a 30–60 tick cooldown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b9931750833391f1c24cf5643e42