### PR TITLE
Add perception gene for creature sensing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# EvoTerrarium
+
+This project simulates evolving creatures in a small 3D world.
+
+## Genes
+
+Each creature has a set of genes controlling behavior and physiology:
+
+- `size` – body scale and energy capacity.
+- `speed` – base acceleration and leg length.
+- `thermo` – preferred environmental temperature.
+- `climb` – ability to traverse slopes.
+- `swim` – swimming efficiency and tail/fins.
+- `social` – alignment, cohesion and mating tendencies.
+- `perception` – sensory range for detecting other entities and resources.
+- `diet` – herbivore (0) or carnivore (1).
+
+`perception` is inherited and mutated independently. It now drives the sensing
+radius in the simulation loop and also affects the head size in the creature
+visualization. Documentation previously referencing `social` for sensing now
+refers to `perception`.

--- a/src/bundle.js
+++ b/src/bundle.js
@@ -79,7 +79,7 @@
       let obj=this.objects.get(e.id);
       if(!obj){obj=this._create();this.objects.set(e.id,obj);this.group.add(obj.group);}
       seen.add(e.id);
-      const g=e.genes||{}; // trait mapping: size->scale, speed->legs, climb->leg thickness, swim->tail+fins, social->head
+      const g=e.genes||{}; // trait mapping: size->scale, speed->legs, climb->leg thickness, swim->tail+fins, perception->head
       const s=(0.35+(g.size||0)*0.9+(e.mode==='swim'?-0.1:0))*CREATURE_SCALE;
       const tiltX=(e.vz||0)*0.06,tiltZ=-(e.vx||0)*0.06;
       obj.group.position.set(e.x,e.y,e.z);
@@ -89,8 +89,8 @@
       const bodyLen=s*2.0;
       obj.body.scale.set(s*1.2,s*0.7,bodyLen);
 
-      // social -> head size
-      const headScale=s*(0.6+(g.social||0)*0.4);
+      // perception -> head size
+      const headScale=s*(0.6+(g.perception||0)*0.4);
       obj.head.position.set(0,0,bodyLen*0.5);
       obj.head.scale.set(headScale,headScale,headScale);
 

--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -85,7 +85,7 @@ function gdist(a,b){
   let d = Math.abs(a.size-b.size)*0.8+Math.abs(a.speed-b.speed)*0.6+
           Math.abs(a.thermo-b.thermo)*0.8+Math.abs(a.climb-b.climb)*0.6+
           Math.abs(a.swim-b.swim)*0.6+Math.abs(a.social-b.social)*0.4+
-          (a.diet!==b.diet?0.4:0);
+          Math.abs(a.perception-b.perception)*0.4+(a.diet!==b.diet?0.4:0);
   const ba=a.behavior||{}, bb=b.behavior||{};
   const keys=['forage','drink','mate','rest','escape','explore'];
   for(const k of keys){
@@ -111,6 +111,7 @@ function newGenes(base){
     climb:clamp01((base&&base.climb||rand())+(rand()*2-1)*(MUTATION_WIDTH*0.6)),
     swim:clamp01((base&&base.swim||rand())+(rand()*2-1)*(MUTATION_WIDTH*0.6)),
     social:clamp01((base&&base.social||rand())+(rand()*2-1)*(MUTATION_WIDTH*0.6)),
+    perception:clamp01((base&&base.perception||rand())+(rand()*2-1)*(MUTATION_WIDTH*0.6)),
     diet:(base&&base.diet!==undefined)?base.diet:(rand()<0.15?1:0),
     drift:(base&&base.drift||0)+rand()*DRIFT_STEP,
     behavior
@@ -181,7 +182,7 @@ function tick(dt){
     map.resources[i]=Math.min(max,cur+max*map.resRegen[i]*dt);
   }
   world.t+=dt;world.season=(Math.sin(world.t*0.05*world.seasonSpeed)*0.5+0.5);rebuild();const maxS=3.0;
-    for(let i=entities.length-1;i>=0;i--){const e=entities[i];e.age+=dt;e.cooldown-=dt;e.hydration-=0.01*dt;e.hydration=Math.max(0,e.hydration);const s=3.0+e.genes.social*4.0;const ar=near(e.x,e.z,s);const b=biomeAt(e.x,e.z);e.biomeExp[b]=Math.min(255,e.biomeExp[b]+1);
+    for(let i=entities.length-1;i>=0;i--){const e=entities[i];e.age+=dt;e.cooldown-=dt;e.hydration-=0.01*dt;e.hydration=Math.max(0,e.hydration);const s=3.0+e.genes.perception*4.0;const ar=near(e.x,e.z,s);const b=biomeAt(e.x,e.z);e.biomeExp[b]=Math.min(255,e.biomeExp[b]+1);
     const maxE=maxEnergy(e.genes.size);
     const targetT=e.genes.thermo,hereT=comfortTempWithDevices(e.x,e.z),comfort=1-Math.abs(hereT-targetT),food=plantRichnessAt(e.x,e.z),atWater=waterNear(e.x,e.z);
     const comfortCoef = 1 + (1 - comfort) * BASAL_COMFORT_FACTOR;
@@ -306,7 +307,7 @@ function snapshot(){
         energy:e.energy,maxEnergy:maxEnergy(e.genes.size),
         genes:{
           size:e.genes.size,speed:e.genes.speed,climb:e.genes.climb,swim:e.genes.swim,
-          thermo:e.genes.thermo,social:e.genes.social,diet:e.genes.diet,
+          thermo:e.genes.thermo,social:e.genes.social,perception:e.genes.perception,diet:e.genes.diet,
           behavior:{
             w_forage:e.genes.behavior.w_forage,w_drink:e.genes.behavior.w_drink,
             w_mate:e.genes.behavior.w_mate,w_rest:e.genes.behavior.w_rest,


### PR DESCRIPTION
## Summary
- Add new `perception` gene to creature genetics with independent mutation and inheritance
- Use `perception` to determine sensing radius in simulation and expose through snapshots
- Visualize `perception` via head size and document gene roles

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check src/sim/worker.js`
- `node --check src/bundle.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2d24b219883338b62b4b56c60b36b