### PR TITLE
Raise base perception sensing radius

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -182,7 +182,7 @@ function tick(dt){
     map.resources[i]=Math.min(max,cur+max*map.resRegen[i]*dt);
   }
   world.t+=dt;world.season=(Math.sin(world.t*0.05*world.seasonSpeed)*0.5+0.5);rebuild();const maxS=3.0;
-    for(let i=entities.length-1;i>=0;i--){const e=entities[i];e.age+=dt;e.cooldown-=dt;e.hydration-=0.01*dt;e.hydration=Math.max(0,e.hydration);const s=3.0+e.genes.perception*4.0;const ar=near(e.x,e.z,s);const b=biomeAt(e.x,e.z);e.biomeExp[b]=Math.min(255,e.biomeExp[b]+1);
+    for(let i=entities.length-1;i>=0;i--){const e=entities[i];e.age+=dt;e.cooldown-=dt;e.hydration-=0.01*dt;e.hydration=Math.max(0,e.hydration);const s=5.0+e.genes.perception*4.0;const ar=near(e.x,e.z,s);const b=biomeAt(e.x,e.z);e.biomeExp[b]=Math.min(255,e.biomeExp[b]+1);
     const maxE=maxEnergy(e.genes.size);
     const targetT=e.genes.thermo,hereT=comfortTempWithDevices(e.x,e.z),comfort=1-Math.abs(hereT-targetT),food=plantRichnessAt(e.x,e.z),atWater=waterNear(e.x,e.z);
     const comfortCoef = 1 + (1 - comfort) * BASAL_COMFORT_FACTOR;


### PR DESCRIPTION
## Summary
- Increase base perception sensing radius from 3 to 5 units in worker logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d841920c8333a100c2e1fa3166b6