### PR TITLE
Remove extra carnivore basal metabolism cost

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -275,7 +275,7 @@ function tick(dt){
     const biome=b; const biomeMul=(biome===2?0.6:(biome===3?1.3:(biome===4?0.7:1.0)));
       let intake=(e.genes.diet===0)?(0.7*plantRichnessAt(e.x,e.z)*biomeMul):0;
       const moveCost=(0.002+0.0006*sp2)*(0.8+e.genes.size*0.6)*(1+avoidSlope*0.8+(inWater?(1-e.genes.swim)*0.9:0));
-      const basal=(0.0008+0.0006*e.genes.size+(e.genes.diet===1?0.0006:0))*comfortCoef;
+      const basal=(0.0008+0.0006*e.genes.size)*comfortCoef;
       if(e.genes.diet===0){
         const {i}=mapCoord(e.x,e.z);
         const available=map.resources[i];


### PR DESCRIPTION
## Summary
- remove carnivore-specific 0.0006 addition to basal metabolism calculation

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d8f611cc8333976c5fee4542c736