### PR TITLE
Adjust predation energy transfer

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -286,7 +286,7 @@ function tick(dt){
       }else{
         e.energy-=(moveCost+basal);
       }
-      if(inWater)e.hydration=clamp01(e.hydration+0.5*dt); if(e.genes.diet===1){for(const o of ar){if(o===e||o.genes.diet!==0)continue;const dx=o.x-e.x,dz=o.z-e.z,d2=dx*dx+dz*dz;if(d2<0.5*0.5){e.energy+=1.0;o.energy-=1.0;}}}
+      if(inWater)e.hydration=clamp01(e.hydration+0.5*dt); if(e.genes.diet===1){for(const o of ar){if(o===e||o.genes.diet!==0)continue;const dx=o.x-e.x,dz=o.z-e.z,d2=dx*dx+dz*dz;if(d2<0.5*0.5){e.energy+=1.5;o.energy-=1.5;}}}
       e.hydration=clamp01(e.hydration);
       if (e.hydration <= 0) e.energy -= DEHYDRATION_PENALTY * dt;
       e.energy=maxE*norm(e.energy,maxE);


### PR DESCRIPTION
## Summary
- increase energy exchanged during predation events from 1.0 to 1.5

## Testing
- `node - <<'NODE' ... NODE` (verifies predator gains 1.5 energy and prey loses 1.5)


------
https://chatgpt.com/codex/tasks/task_e_68a2db30c4f8833382d71d70f35868d1