### PR TITLE
Increase initial organism count to 400

### DIFF
--- a/src/bundle.js
+++ b/src/bundle.js
@@ -170,7 +170,7 @@
       statsEl.textContent=`entities: ${p.entities.length} • time: ${p.world.t.toFixed(1)}s • season:${p.world.season.toFixed(2)} • maxE:${maxE.toFixed(2)}`;
       d('state ok');
     }else if(t==='map'){applyMap(p);}else if(t==='tree'){treeData=p;showTree(true);}else if(t==='selected'){engine.highlightAt(p);}else if(t==='rpgReady'){d('RPG species selected: '+p.species);}else if(t==='error'){statsEl.textContent='worker error: '+p;d('worker error: '+p);}
-  };sim.postMessage({type:'init',payload:{seed:Date.now(),entityCount:200,simCap:parseInt(document.getElementById('simCap').value,10)}});}
+  };sim.postMessage({type:'init',payload:{seed:Date.now(),entityCount:400,simCap:parseInt(document.getElementById('simCap').value,10)}});}
   engine.start();
   seasonSpeed.addEventListener('input',function(){sim&&sim.postMessage({type:'seasonSpeed',payload:parseFloat(this.value)})});
   resScale&&resScale.addEventListener('input',function(){const newScale=parseFloat(this.value);sim&&sim.postMessage({type:'resourceScale', payload:newScale});});

--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -339,7 +339,7 @@ function loop(){
 }
 
 onmessage=(e)=>{try{const t=e.data.type,p=e.data.payload;
-  if(t==='init'){init((p&&p.seed)||1,(p&&p.entityCount)||200,p&&p.simCap||4000);running=true;accumulator=0;lastTime=performance.now();loop();}
+  if(t==='init'){init((p&&p.seed)||1,(p&&p.entityCount)||400,p&&p.simCap||4000);running=true;accumulator=0;lastTime=performance.now();loop();}
   else if(t==='seasonSpeed'){world.seasonSpeed=p||1.0;}
   else if(t==='placeDevice'){devices.push({type:p.type,x:p.x,z:p.z,power:1.0,radius:5.0});}
   else if(t==='pickSelect'){let best=null,bd2=1e9;for(const ent of entities){const dx=ent.x-p.x,dz=ent.z-p.z,d2=dx*dx+dz*dz;if(d2<bd2){bd2=d2;best=ent;}} if(best)postMessage({type:'selected',payload:{x:best.x,z:best.z}});}


### PR DESCRIPTION
## Summary
- Increase default entity spawn count from 200 to 400 for new simulations.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2dd68047c8333a2f3d0e5034eac00