### PR TITLE
feat: persistent exploration direction

### DIFF
--- a/src/sim/worker.js
+++ b/src/sim/worker.js
@@ -125,7 +125,7 @@ function spawnEntity(id){
   speciesHues[sp]=rand();
   regSpecies(sp,0);
   const energy=maxEnergy(g.size)*0.6;
-  return {id,x,z,y:heightAtWorld(x,z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,age:0.0,hydration:1.0,cooldown:30+rand()*30,genes:g,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5)};
+  return {id,x,z,y:heightAtWorld(x,z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,age:0.0,hydration:1.0,cooldown:30+rand()*30,genes:g,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5),searchDir:null,searchTimer:0};
 }
 function reproduce(p){
   const cg=newGenes(p.genes);
@@ -138,7 +138,7 @@ function reproduce(p){
     regSpecies(sp,p.species);
   }
   const energy=maxEnergy(cg.size)*0.6;
-    entities.push({id:nextId++,x:p.x+(rand()*2-1)*0.5,z:p.z+(rand()*2-1)*0.5,y:heightAtWorld(p.x,p.z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,hydration:0.8,age:0.0,cooldown:30+rand()*30,genes:cg,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5)});
+    entities.push({id:nextId++,x:p.x+(rand()*2-1)*0.5,z:p.z+(rand()*2-1)*0.5,y:heightAtWorld(p.x,p.z)+0.35*CREATURE_SCALE,vx:0,vz:0,yaw:0,energy,hydration:0.8,age:0.0,cooldown:30+rand()*30,genes:cg,species:sp,mode:'walk',behavior:'explore',biomeExp:new Uint8Array(5),searchDir:null,searchTimer:0});
 }
 // env
 function comfortTempBase(z){return (Math.sin(z*0.07)*0.5+0.5);} function comfortTempWithDevices(x,z){let t=comfortTempBase(z);for(const d of devices){if(d.type!=='heater')continue;const dx=d.x-x,dz=d.z-z;const r2=dx*dx+dz*dz;const fall=Math.exp(-r2/(d.radius*d.radius));t=clamp01(t+d.power*0.25*fall);}return t;}
@@ -224,6 +224,17 @@ function tick(dt){
         if(v>th && v>maxDes){maxDes=v;behavior=k;}
       }
       e.behavior=behavior;
+      if (behavior === 'explore') {
+        e.searchTimer -= dt;
+        if (!e.searchDir || e.searchTimer <= 0) {
+          const ang = rand() * Math.PI * 2;
+          e.searchDir = {x: Math.cos(ang), z: Math.sin(ang)};
+          e.searchTimer = 4 + rand() * 4;
+        }
+      } else {
+        e.searchDir = null;
+        e.searchTimer = 0;
+      }
       let sepX=0,sepZ=0,aliX=0,aliZ=0,cohX=0,cohZ=0,nali=0,ncoh=0;
       for(const o of ar){
         if(o===e)continue;
@@ -251,7 +262,14 @@ function tick(dt){
       const mateX=cohX*0.5, mateZ=cohZ*0.5;
       const escapeX=fleeX*1.7, escapeZ=fleeZ*1.7;
       const restX=0, restZ=0;
-      const exploreX=(rand()*2-1)*0.3, exploreZ=(rand()*2-1)*0.3;
+      let exploreX, exploreZ;
+      if (e.searchDir) {
+        exploreX = e.searchDir.x * 0.3 + (rand()*2-1)*0.05;
+        exploreZ = e.searchDir.z * 0.3 + (rand()*2-1)*0.05;
+      } else {
+        exploreX = (rand()*2-1)*0.3;
+        exploreZ = (rand()*2-1)*0.3;
+      }
       const vecs={
         forage:{x:forageX,z:forageZ},
         drink:{x:drinkX,z:drinkZ},


### PR DESCRIPTION
## Summary
- initialize searchDir and searchTimer state for new and reproduced entities
- explore behavior now persists in chosen direction with timer and noise, resetting when seeking resources

## Testing
- `node --check src/sim/worker.js`


------
https://chatgpt.com/codex/tasks/task_e_68a2e1e1fa2483338c05d4cf6933fdc1